### PR TITLE
Update production.config.js

### DIFF
--- a/config/client/production.config.js
+++ b/config/client/production.config.js
@@ -29,8 +29,6 @@ const getConfig = config => ({
     path: config.build.target,
 
     publicPath: generateCdnPath(config),
-    // necessary for HMR to know where to load the hot update chunks
-    sourceMapFilename: '[name]-[chunkhash].js.map',
   },
 
   // context: resolve('sources'),


### PR DESCRIPTION
remove sourceMapFilename for [We recommend only using the [file] placeholder, as the other placeholders won't work when generating SourceMaps for non-chunk files.](https://webpack.js.org/configuration/output/#output-sourcemapfilename)